### PR TITLE
Define table properties for Firefox

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -113,6 +113,11 @@ body {
   tab-size: 4;
 }
 
+.memorytable {
+  border-spacing: 2;
+  height: 20;
+}
+
 table.helptable {
   background-color: #ffeda0;
   border-collapse: collapse;


### PR DESCRIPTION
Firefox requires defined properties for tables, to display the same as Chrome. The "height:" fixes the issue of different table heights in Chrome and Firefox